### PR TITLE
Allow specifying the name when calling sts:GetFedertionToken

### DIFF
--- a/aws_consoler/cli.py
+++ b/aws_consoler/cli.py
@@ -73,6 +73,9 @@ def main(argv=sys.argv[1:]):
     gen_grp.add_argument(
         "-v", "--verbose", action="count",
         help="Verbosity, repeat for more verbose output (up to 3)")
+    gen_grp.add_argument(
+        "-n", "--name", default="aws_consoler",
+        help="Name to use when getting the federation token.")
     logger.debug("General group ready.")
 
     adv_grp = parser.add_argument_group(title="Advanced arguments")

--- a/aws_consoler/logic.py
+++ b/aws_consoler/logic.py
@@ -69,7 +69,7 @@ def run(args: argparse.Namespace) -> str:
         # for the largest set of possible permissions.
         try:
             resp = sts.get_federation_token(
-                Name="aws_consoler",
+                Name= args.name if args.name is not None else "aws_consoler",
                 PolicyArns=[
                     {"arn": "arn:aws:iam::aws:policy/AdministratorAccess"}
                 ])


### PR DESCRIPTION
Useful when you have an IAM policy restricting the names you can get tokens for.

For example, if the following permission boundry is applied to the compromised user. It's unlikely that we happen to compromise a user named `aws_consoler` :)

```json
{
      "Statement": [
        {
          "Action": "sts:GetFederationToken",
          "Effect": "Allow",
          "Resource": "arn:aws:sts::619346007778:federated-user/${aws:username}"
        }
      ],
      "Version": "2012-10-17"
}
```